### PR TITLE
fix(header): add User-Agent header to respect Nominatim requirements

### DIFF
--- a/nominatim.qml
+++ b/nominatim.qml
@@ -82,6 +82,7 @@ Item {
     }
     let viewbox = GeometryUtils.reprojectRectangle(context.targetExtent, context.targetExtentCrs, CoordinateReferenceSystemUtils.fromDescription(parameters["service_crs"])).toString().replace(" : ", ",")
     request.open("GET", parameters["service_url"] + "?q=" + encodeURIComponent(string) + '&viewbox=' + viewbox + '&format=geojson&extratags=1&addressdetails=1&limit=20')
+    request.setHeader("User-Agent", "QField")
     request.send();
   }
 }


### PR DESCRIPTION
[Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/) requires the use of a `User-Agent` header.

If not defined we receive an error :

```
Access denied. See https://operations.osmfoundation.org/policies/nominatim/
```

This PR add a header for the request.

